### PR TITLE
TweepError log: fix AttributeError

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -49,7 +49,7 @@ def tweet(text):
     try:
         api.update_status(text)
     except tweepy.error.TweepError as e:
-        log(e.message)
+        log(str(e))
     else:
         log("Tweeted: " + text)
 


### PR DESCRIPTION
This change fixes this error:

```
Traceback (most recent call last):
  File "bot.py", line 84, in <module>
    tweet(tweet_text)
  File "bot.py", line 67, in tweet
    log(e.message)
AttributeError: 'TweepError' object has no attribute 'message'
```

I guess the error is a little different with recent versions of tweepy. I'm using 3.5.0.